### PR TITLE
Should fix #2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "csv-helper"
-version = "0.2.1"
+version = "0.2.2"
 description = "A simple CLI for imputing masked counts in CSV data"
 authors = [
     {name = "Andrew Tiu", email = "andrew.tiu88@gmail.com"},

--- a/src/csv_helper/main.py
+++ b/src/csv_helper/main.py
@@ -353,7 +353,9 @@ def impute_capped(denom: int, fill_range: FillRange, rng: Generator) -> int:
     Return a random integer from a range that is capped
     at the 'denominator' value
     """
-    return rng.integers(fill_range.lb, denom, size=1, endpoint=True)
+    # WARN: specifying size=1 instead of leaving size = None
+    # will return single-value list instead of just the value
+    return rng.integers(fill_range.lb, denom, endpoint=True)
 
 
 @impute_app.command("pair")
@@ -678,7 +680,7 @@ def impute_pair(
             f"{imp_sizes[0]:_}",
         )
         table.add_row(
-            f"[blue]Proportion of imputed values in[/blue] '{fill_cols.numerator}",
+            f"[blue]Proportion of imputed values in[/blue] '{fill_cols.numerator}'",
             f"{(imp_sizes[0] / df.height):0.2f} (n = {df.height:_})",
             end_section=True,
         )

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -599,6 +599,10 @@ def test_impute_pair_sep(tmp_path, test_data_sep):
     df_num = pl.read_csv(num_file, infer_schema_length=0)
     df_out = pl.read_csv(out_file, infer_schema_length=0)
     assert df_num.shape == df_out.shape
+    assert (
+        df_out.select((pl.col("cases") == f"<={fill_range[1]}").any()).item() is False
+    )
+    assert df_num.null_count().equals(df_out.null_count()) is True
 
     # NOTE: can't test if all imputed cases <= all-cause since we don't save imputed all-cause in this case
     df = df_num.join(
@@ -688,6 +692,10 @@ def test_impute_pair_sep_output(tmp_path, test_data_sep):
 
     df_out = pl.read_csv(out_file, infer_schema_length=0)
     assert df_num.shape == df_out.shape
+    assert (
+        df_out.select((pl.col("cases") == f"<={fill_range[1]}").any()).item() is False
+    )
+    assert df_num.null_count().equals(df_out.null_count()) is True
 
     df_sep_out = pl.read_csv(sep_out, infer_schema_length=0)
     assert df_denom.shape == df_sep_out.shape


### PR DESCRIPTION
Fixes issue caused by using `rng.integers(..., size=1)` instead of `rng.integers(..., size=None)` (the default). The former returns a single-value array instead of the value itself. This caused `nulls` to be silently inserted into the imputed data `impute_capped()`.